### PR TITLE
Set the namespace scope when creating the new app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ export PROJECT=appuio-infra
 oc new-project $PROJECT
 oc adm policy add-cluster-role-to-user edit system:serviceaccount:$PROJECT:default
 oc adm policy add-cluster-role-to-user system:image-pruner system:serviceaccount:$PROJECT:default
-oc new-app https://github.com/appuio/appuio-pruner
+oc new-app -n $PROJECT https://github.com/appuio/appuio-pruner
 ```


### PR DESCRIPTION
It avoids to create the app in the active project instead of the new one.